### PR TITLE
Export type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.cjs",
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Was getting an error in a project where I use `financial-number` b/c it couldn't find the types for this module